### PR TITLE
Added Draft Support Slug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-button",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A plugin for Strapi CMS that adds a preview button and live view button to the content manager edit view.",
   "license": "MIT",
   "strapi": {

--- a/server/services/preview-button.js
+++ b/server/services/preview-button.js
@@ -19,23 +19,26 @@ module.exports = ( { strapi } ) => ( {
     const publishedBasePath = get( published, 'basePath', null );
     const publishedQuery = get( published, 'query', {} );
     const draftBasePath = get( draft, 'basePath', null );
-    let draftQuery = get( draft, 'query', {} );
+    let draftQuery = get( draft, 'query', null );
 
-    // Include the required `secret` into the draft query params.
-    draftQuery.secret = process.env.STRAPI_PREVIEW_SECRET;
 
     // Optionally include the `targetField` value in the draft query params.
     // Only collection types truly require the `targetField`, while single types
     // can optionally use the `basePath` to help build the desired URL.
-    if ( targetField && targetFieldValue ) {
+    if ( targetField && targetFieldValue && draftQuery ) {
+      // Include the required `secret` into the draft query params.
+      draftQuery.secret = process.env.STRAPI_PREVIEW_SECRET;
       draftQuery[ targetField ] = targetFieldValue;
     }
+
+    const slugDraft = !draftQuery ? targetFieldValue : null
+    draftQuery = draftQuery || {}
 
     // Build final URLs.
     const draftUrl = buildUrl(
       process.env.STRAPI_PREVIEW_DRAFT_URL,
       draftBasePath,
-      null,
+      slugDraft,
       draftQuery
     );
 


### PR DESCRIPTION
### **For draft slug** 
```javascript
module.exports = {
  'preview-button': {
    enabled: true,
    config: {
      contentTypes: [
        {
          uid: 'api::about.about',
          targetField: 'slug',
          draft: {
            basePath: 'about',
          },
          published: {
            basePath: 'about',
          },
        },
      ],
    },
  },
};
```
Draft URL path
```
https://example.com/api/preview/about/slug_value?secret=YOURSECRET
```

Published URL path
```
https://example.com/about/slug_value
```
### **For draft query** 
```javascript
module.exports = {
  'preview-button': {
    enabled: true,
    config: {
      contentTypes: [
        {
          uid: 'api::about.about',
          targetField: 'slug',
          draft: {
            basePath: 'about',
            query: {},
          },
          published: {
            basePath: 'about',
          },
        },
      ],
    },
  },
};
```
Draft URL path
```
https://example.com/api/preview/about?slug=slug_value&secret=YOURSECRET
```

Published URL path
```
https://example.com/about/slug_value
```